### PR TITLE
@SeoroMin

### DIFF
--- a/pykrx/website/krx/market/wrap.py
+++ b/pykrx/website/krx/market/wrap.py
@@ -495,6 +495,7 @@ def get_market_trading_value_and_volume_on_market_by_date(fromdate: str, todate:
     df = df.replace('[^-\w]', '', regex=True)
     df = df.replace('', '0')
     df = df.astype(np.int64)
+    df['전체'] = df.iloc[:, 0:-1].sum(axis=1)
     return df.sort_index()
 
 


### PR DESCRIPTION
get_market_trading_value_and_volume_on_market_by_date 함수 호출 시 '전체' column이 계속 0으로 뜨는 이슈가 있었습니다.
전체 column이 올바르게 출력될 수 있도록, 다른 열을 합쳐서 전체 column을 만드는 코드를 추가했습니다.

code 확인해보시고 merge해주시면 감사하겠습니다!