### PR TITLE
add Referer on website comm webio.py class Get. If not, krx returns n…

### DIFF
--- a/pykrx/website/comm/webio.py
+++ b/pykrx/website/comm/webio.py
@@ -1,10 +1,9 @@
 import requests
 from abc import abstractmethod
 
-
 class Get:
     def __init__(self):
-        self.headers = {"User-Agent": "Mozilla/5.0"}
+        self.headers = {"User-Agent": "Mozilla/5.0", "Referer":"http://openapi.krx.co.kr/contents/OPP/USES/service/OPPUSES001_S2.cmd?BO_ID=SsgXTEspyJESKvyXZtCU"}
 
     def read(self, **params):
         resp = requests.get(self.url, headers=self.headers, params=params)
@@ -18,7 +17,7 @@ class Get:
 
 class Post:
     def __init__(self, headers=None):
-        self.headers = {"User-Agent": "Mozilla/5.0"}
+        self.headers = {"User-Agent": "Mozilla/5.0", "Referer":"http://openapi.krx.co.kr/contents/OPP/USES/service/OPPUSES001_S2.cmd?BO_ID=SsgXTEspyJESKvyXZtCU"}
         if headers is not None:
             self.headers.update(headers)
 


### PR DESCRIPTION
…ull except ohlcv
2024년 7월 초 부터, Referer 없으면,  ohlcv 만 조회가 되고 나머지는 조회가 되지 않습니다. 
krx 직접 조회하면 조회됩니다. 
Referer에 krx 주소 아무 주소나 넣으면 되는 듯 합니다. 
일단은 fork 된거에서 수정하고  
아나콘다 env 에서 "pip install ." 해서 정상동작해서 사용하고 있습니다. 