### PR TITLE
replace pkg_resources to importlib

### DIFF
--- a/pykrx/__init__.py
+++ b/pykrx/__init__.py
@@ -1,7 +1,7 @@
 import platform
 import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
-import pkg_resources
+import importlib.resources as resources
 from . import bond
 from . import stock
 
@@ -11,13 +11,13 @@ if os == "Darwin":
     plt.rc('font', family="AppleGothic")
 
 else:
-    font_path = pkg_resources.resource_filename('pykrx', 'NanumBarunGothic.ttf')
-    fe = fm.FontEntry(
-        fname=font_path,
-        name='NanumBarunGothic'
-    )
-    fm.fontManager.ttflist.insert(0, fe)
-    plt.rc('font', family=fe.name)
+    with resources.path('pykrx', 'NanumBarunGothic.ttf') as font_path:
+        fe = fm.FontEntry(
+            fname=str(font_path),
+            name='NanumBarunGothic'
+        )
+        fm.fontManager.ttflist.insert(0, fe)
+        plt.rc('font', family=fe.name)
 
 plt.rcParams['axes.unicode_minus'] = False
 


### PR DESCRIPTION
Python3.12 로 이 패키지를 사용하려고 했는데 `pkg_resources` 때문에 다음과 같은 에러가 났습니다
```
  File "/Users/keunsoopark/Desktop/xnwk/from-others/gemana/.venv/lib/python3.12/site-packages/pykrx/__init__.py", line 4, in <module>
    import pkg_resources
  File "/Users/keunsoopark/Desktop/xnwk/from-others/gemana/.venv/lib/python3.12/site-packages/pkg_resources/__init__.py", line 2191, in <module>
    register_finder(pkgutil.ImpImporter, find_on_path)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'ImpImporter'. Did you mean: 'zipimporter'?
```

`pkg_resources` 가 Python3.12 에서는 더이상 제공되지 않는 package 이고, [setuptools](https://setuptools.pypa.io/en/latest/pkg_resources.html) 에서도 `importlib` 으로 교체하라고 나와있네요
```
Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.
```