### PR TITLE
feat: 전종목 기본정보 조회 함수 추가 (#272)

### DIFF
--- a/pykrx/stock/stock_api.py
+++ b/pykrx/stock/stock_api.py
@@ -2858,6 +2858,26 @@ def get_stock_major_changes(ticker: str) -> DataFrame:
     return krx.get_stock_major_changes(ticker)
 
 
+def get_market_ohlcv_by_market(market: str):
+    """티커별로 정리된 전종목 OHLCV
+
+    Args:
+        date   (str): 조회 일자 (YYYYMMDD)
+        market (str): 조회 시장 (KOSPI/KOSDAQ/KONEX/ALL)
+
+    Returns:
+        DataFrame:
+                     시가   고가   저가   종가  거래량    거래대금
+            티커
+            060310   2150   2390   2150   2190  981348  2209370985
+            095570   3135   3200   3100   3130   89871   282007385
+            006840  17050  17200  16500  16500   30567   512403000
+            054620   8550   8740   8400   8650  647596  5525789290
+            265520  22150  23100  22050  22400  255846  5798313650
+    """
+    return krx.get_market_ohlcv_by_market(market)
+
+
 if __name__ == "__main__":
     pd.set_option("display.expand_frame_repr", False)
     # print(get_market_price_change_by_ticker(

--- a/pykrx/website/krx/market/core.py
+++ b/pykrx/website/krx/market/core.py
@@ -1419,6 +1419,47 @@ class 기업주요변동사항(KrxWebIo):
         return DataFrame(result["block1"])
 
 
+class 전종목기본정보(KrxWebIo):
+    @property
+    def bld(self):
+        return "dbms/MDC/STAT/standard/MDCSTAT01901"
+
+    def fetch(
+        self,
+        mktId: str = "ALL",
+        segTpCd: str = "ALL",
+    ) -> DataFrame:
+        """[12005] 전종목 기본정보
+
+        Args:
+            mktId   (str): 시장구분
+             - ALL: 전체
+             - STK: KOSPI
+             - KSQ: KOSDAQ
+             - KNX: KONEX
+            segTpCd (str): KOSDAQ 검색 구분
+                - ALL: 전체
+                - 1 : KOSDAQ GLOBAL
+
+        Returns:
+            DataFrame:
+                >> 전종목기본정보().fetch(mktId="ALL", segTpCd="ALL").head()
+                        ISU_CD ISU_SRT_CD        ISU_NM ISU_ABBRV                       ISU_ENG_NM     LIST_DD      MKT_TP_NM SECUGRP_NM SECT_TP_NM KIND_STKCERT_TP_NM PARVAL   LIST_SHRS
+                0  KR7098120009     098120  (주)마이크로컨텍솔루션   마이크로컨텍솔  Micro Contact Solution Co.,Ltd.  2008/09/23         KOSDAQ         주권      중견기업부                보통주    500   8,312,766
+                1  KR7009520008     009520      (주)포스코엠텍     포스코엠텍            POSCO M-TECH CO.,LTD.  1997/11/10  KOSDAQ GLOBAL         주권      우량기업부                보통주    500  41,642,703
+                2  KR7095570008     095570     AJ네트웍스보통주    AJ네트웍스             AJ Networks Co.,Ltd.  2015/08/21          KOSPI         주권                           보통주  1,000  45,252,759
+                3  KR7006840003     006840      AK홀딩스보통주     AK홀딩스                AK Holdings, Inc.  1999/08/11          KOSPI         주권                           보통주  5,000  13,247,561
+                4  KR7282330000     282330     BGF리테일보통주    BGF리테일                       BGF Retail  2017/12/08          KOSPI         주권                           보통주  1,000  17,283,906
+        """
+        if mktId == "KSQ":
+            result = self.read(mktId=mktId, segTpCd=segTpCd)
+            return DataFrame(result["OutBlock_1"])
+
+        else:
+            result = self.read(mktId=mktId)
+            return DataFrame(result["OutBlock_1"])
+
+
 if __name__ == "__main__":
     pd.set_option("display.width", None)
     # print(개별종목_공매도_잔고().fetch("20200106", "20200110", "KR7005930003"))

--- a/pykrx/website/krx/market/wrap.py
+++ b/pykrx/website/krx/market/wrap.py
@@ -21,6 +21,7 @@ from pykrx.website.krx.market.core import (
     외국인보유량_개별추이,
     외국인보유량_전종목,
     전종목_공매도_잔고,
+    전종목기본정보,
     전종목등락률,
     전종목시세,
     전체지수기본정보,
@@ -1740,6 +1741,48 @@ def get_stock_major_changes(ticker: str) -> DataFrame:
     df = df.replace("", "-")
     df.index = pd.to_datetime(df.index, format="%Y/%m/%d")
     df = df.astype({"액면변경전": np.int16})
+    return df.sort_index()
+
+
+@dataframe_empty_handler
+def get_market_ohlcv_by_market(market: str = "ALL") -> DataFrame:
+    """[12005] 전종목 기본정보
+
+    Args:
+        market (str): 검색 시장 (ALL/KOSPI/KOSDAQ/KONEX)
+    Returns:
+        DataFrame:
+
+            >> get_market_ohlcv_by_market(market="ALL")
+                        표준코드         한글종목명   한글종목약명                            영문종목명        상장일           시장구분 증권구분    소속부 주식종류   액면가     상장주식수
+            티커
+            098120  KR7098120009  (주)마이크로컨텍솔루션  마이크로컨텍솔  Micro Contact Solution Co.,Ltd. 2008-09-23         KOSDAQ   주권  중견기업부  보통주   500   8312766
+            009520  KR7009520008      (주)포스코엠텍    포스코엠텍            POSCO M-TECH CO.,LTD. 1997-11-10  KOSDAQ GLOBAL   주권  우량기업부  보통주   500  41642703
+            095570  KR7095570008     AJ네트웍스보통주   AJ네트웍스             AJ Networks Co.,Ltd. 2015-08-21          KOSPI   주권         보통주  1000  45252759
+    """
+
+    market2mktid = {"ALL": "ALL", "KOSPI": "STK", "KOSDAQ": "KSQ", "KONEX": "KNX"}
+
+    df = 전종목기본정보().fetch(market2mktid[market])
+    df.columns = [
+        "표준코드",
+        "티커",
+        "한글종목명",
+        "한글종목약명",
+        "영문종목명",
+        "상장일",
+        "시장구분",
+        "증권구분",
+        "소속부",
+        "주식종류",
+        "액면가",
+        "상장주식수",
+    ]
+    df = df.set_index("티커")
+    df["액면가"] = df["액면가"].replace(r"[^-\w\.]", "", regex=True)
+    df["상장주식수"] = df["상장주식수"].replace(r"[^-\w\.]", "", regex=True)
+    df["상장일"] = pd.to_datetime(df["상장일"], format="%Y/%m/%d")  # 상장일
+    df = df.astype({"상장주식수": np.int64})
     return df.sort_index()
 
 

--- a/tests/integration/test_market_api.py
+++ b/tests/integration/test_market_api.py
@@ -693,5 +693,31 @@ class TestStockExhaustionRatesOfForeignInvestmentByDateTest:
         assert len(df) == 1
 
 
+class TestMarketOhlcvByMarket:
+    @pytest.mark.vcr
+    def test_all_market(self):
+        df = stock.get_market_ohlcv_by_market("ALL")
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) > 0
+        assert df.index.name == "티커"
+        expected_columns = [
+            "표준코드",
+            "한글종목명",
+            "한글종목약명",
+            "영문종목명",
+            "상장일",
+            "시장구분",
+            "증권구분",
+            "소속부",
+            "주식종류",
+            "액면가",
+            "상장주식수",
+        ]
+        assert list(df.columns) == expected_columns
+        assert pd.api.types.is_datetime64_any_dtype(df["상장일"])
+        assert df["상장주식수"].dtype == np.int64
+        assert (df.index == df.index.sort_values()).all()
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
#272 

[12005] 전종목 기본정보 조회 함수(`get_market_ohlcv_by_market`) 추가 
```
    Args:
        market (str): 검색 시장 (ALL/KOSPI/KOSDAQ/KONEX)
    Returns:
        DataFrame:

            >> get_market_ohlcv_by_market(market="ALL")
                        표준코드         한글종목명   한글종목약명                            영문종목명        상장일           시장구분 증권구분    소속부 주식종류   액면가     상장주식수
            티커
            098120  KR7098120009  (주)마이크로컨텍솔루션  마이크로컨텍솔  Micro Contact Solution Co.,Ltd. 2008-09-23         KOSDAQ   주권  중견기업부  보통주   500   8312766
            009520  KR7009520008      (주)포스코엠텍    포스코엠텍            POSCO M-TECH CO.,LTD. 1997-11-10  KOSDAQ GLOBAL   주권  우량기업부  보통주   500  41642703
            095570  KR7095570008     AJ네트웍스보통주   AJ네트웍스  
```
